### PR TITLE
Make Format actually faster

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -77,7 +77,7 @@ func Format(template string, args ...interface{}) string {
 					//argNumber, err := strconv.Atoi(argNumberStr)
 					if err == nil && len(args) > argNumber {
 						// get number from placeholder
-						strVal := getItemAsStr(&args[argNumber])
+						strVal := getItemAsStr(args[argNumber])
 						formattedStr.WriteString(strVal)
 					} else {
 						formattedStr.WriteByte('{')
@@ -152,7 +152,7 @@ func FormatComplex(template string, args map[string]interface{}) string {
 					arg, ok := args[argNumberStr]
 					if ok {
 						// get number from placeholder
-						strVal := getItemAsStr(&arg)
+						strVal := getItemAsStr(arg)
 						formattedStr.WriteString(strVal)
 					} else {
 						formattedStr.WriteByte('{')
@@ -173,55 +173,40 @@ func FormatComplex(template string, args map[string]interface{}) string {
 }
 
 // todo: umv: impl format passing as param
-func getItemAsStr(item *interface{}) string {
+func getItemAsStr(item interface{}) string {
 	var strVal string
 	//var err error
-	switch (*item).(type) {
+	switch i := item.(type) {
 	case string:
-		strVal = (*item).(string)
-		break
+		strVal = item.(string)
 	case int8:
-		strVal = strconv.FormatInt(int64((*item).(int8)), 10)
-		break
+		strVal = strconv.FormatInt(int64(i), 10)
 	case int16:
-		strVal = strconv.FormatInt(int64((*item).(int16)), 10)
-		break
+		strVal = strconv.FormatInt(int64(i), 10)
 	case int32:
-		strVal = strconv.FormatInt(int64((*item).(int32)), 10)
-		break
+		strVal = strconv.FormatInt(int64(i), 10)
 	case int64:
-		strVal = strconv.FormatInt((*item).(int64), 10)
-		break
+		strVal = strconv.FormatInt(i, 10)
 	case int:
-		strVal = strconv.FormatInt(int64((*item).(int)), 10)
-		break
+		strVal = strconv.FormatInt(int64(i), 10)
 	case uint8:
-		strVal = strconv.FormatUint(uint64((*item).(uint8)), 10)
-		break
+		strVal = strconv.FormatUint(uint64(i), 10)
 	case uint16:
-		strVal = strconv.FormatUint(uint64((*item).(uint16)), 10)
-		break
+		strVal = strconv.FormatUint(uint64(i), 10)
 	case uint32:
-		strVal = strconv.FormatUint(uint64((*item).(uint32)), 10)
-		break
+		strVal = strconv.FormatUint(uint64(i), 10)
 	case uint64:
-		strVal = strconv.FormatUint((*item).(uint64), 10)
-		break
+		strVal = strconv.FormatUint(i, 10)
 	case uint:
-		strVal = strconv.FormatUint(uint64((*item).(uint)), 10)
-		break
+		strVal = strconv.FormatUint(uint64(i), 10)
 	case bool:
-		strVal = strconv.FormatBool((*item).(bool))
-		break
+		strVal = strconv.FormatBool(i)
 	case float32:
-		strVal = strconv.FormatFloat(float64((*item).(float32)), 'f', -1, 32)
-		break
+		strVal = strconv.FormatFloat(float64(i), 'f', -1, 32)
 	case float64:
-		strVal = strconv.FormatFloat((*item).(float64), 'f', -1, 64)
-		break
+		strVal = strconv.FormatFloat(i, 'f', -1, 64)
 	default:
-		strVal = fmt.Sprintf("%v", *item)
-		break
+		strVal = fmt.Sprintf("%v", item)
 	}
 	return strVal
 }


### PR DESCRIPTION
Format is now 1% ns faster on average and >30% worse in memory consumption than fmt. Note that I didn't change the fmt tests at all so this means that there the benchmarks are +- 1% accurate. Also, FormatComplex7Arg seems to jump +-17% speed at random.
```
name                  old time/op    new time/op    delta
Format4Arg-24            520ns ± 1%     510ns ± 1%  -1.87%  (p=0.000 n=10+10)
Fmt4Arg-24               523ns ± 1%     518ns ± 1%  -0.83%  (p=0.000 n=10+9)
Format6Arg-24            554ns ± 1%     545ns ± 1%  -1.59%  (p=0.000 n=10+10)
Fmt6Arg-24               552ns ± 1%     556ns ± 1%  +0.80%  (p=0.000 n=10+10)
FormatComplex7Arg-24     313ns ± 1%     313ns ± 0%    ~     (p=0.644 n=10+9)

name                  old alloc/op   new alloc/op   delta
Format4Arg-24             352B ± 0%      352B ± 0%    ~     (all equal)
Fmt4Arg-24                304B ± 0%      304B ± 0%    ~     (all equal)
Format6Arg-24             416B ± 0%      416B ± 0%    ~     (all equal)
Fmt6Arg-24                320B ± 0%      320B ± 0%    ~     (all equal)
FormatComplex7Arg-24      326B ± 0%      326B ± 0%    ~     (all equal)

name                  old allocs/op  new allocs/op  delta
Format4Arg-24             8.00 ± 0%      8.00 ± 0%    ~     (all equal)
Fmt4Arg-24                5.00 ± 0%      5.00 ± 0%    ~     (all equal)
Format6Arg-24             8.00 ± 0%      8.00 ± 0%    ~     (all equal)
Fmt6Arg-24                5.00 ± 0%      5.00 ± 0%    ~     (all equal)
FormatComplex7Arg-24      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
```